### PR TITLE
Fix overflowing progress bars

### DIFF
--- a/ycms/cms/models/bed_assignment.py
+++ b/ycms/cms/models/bed_assignment.py
@@ -121,7 +121,9 @@ class BedAssignment(AbstractBaseModel):
         ) < 0:
             return None
 
-        if (total := int((self.discharge_date - self.admission_date).days)) <= 0:
+        if (
+            total := int((self.discharge_date.date() - self.admission_date.date()).days)
+        ) <= 0:
             return 100
 
         return int((duration / total) * 100)

--- a/ycms/cms/templates/ward/ward_beds.html
+++ b/ycms/cms/templates/ward/ward_beds.html
@@ -47,7 +47,7 @@
             </div>
         {% endif %}
         {% if patient.current_stay.accompanied %}
-            <div class="flex flex-col gap-1 w-full">
+            <div class="flex flex-col gap-1 w-full col-start-2">
                 <div class=" flex flex-col items-center">
                     <i icon-name="users"
                        class="w-10 h-10 rounded-lg bg-gray-100 text-gray-600"></i>


### PR DESCRIPTION
<!-- Copyright [2019] [Integreat Project] -->
<!---->
<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
<!-- you may not use this file except in compliance with the License. -->
<!-- You may obtain a copy of the License at -->
<!---->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!---->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->
### Short description
<!-- Describe this PR in one or two sentences. -->

The overflow was occurring when the release day is today, but "not yet", i.e. at some time later today.



### Proposed changes
<!-- Describe this PR in more detail. -->

- fix progress overflow
- also tweak how accompanying persons are displayed in the room card, by always fixing them to the right column. This should either show them next to the person in the room as before, or, if through algorithmic assignments 3 people are in a 2 bed room, it shows the accompanying person under the correct patient


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- 
- 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n/a
