### PR TITLE
Make patient list table responsive

### DIFF
--- a/ycms/cms/templates/_raw.html
+++ b/ycms/cms/templates/_raw.html
@@ -43,7 +43,7 @@ limitations under the License.
     <body class="font-default text-lg bg-background-50">
         {% if messages and not messages_suppressed %}
             <div id="messages"
-                 class="absolute top-8 right-8 flex flex-col max-w-screen-sm z-50">
+                 class="absolute md:top-8 md:right-8 flex flex-col max-w-screen-sm z-50">
                 {% for msg in messages %}
                     {% if msg.level_tag == 'info' %}
                         <div class="message bg-blue-100 border-l-4 border-blue-500 dark:bg-blue-700 dark:border-blue-400"

--- a/ycms/cms/templates/patients/patients_list.html
+++ b/ycms/cms/templates/patients/patients_list.html
@@ -15,35 +15,34 @@
                type="text"
                placeholder="{% translate "Search for name..." %}"
                class="mb-2" />
-        <div class="shadow-md overflow-x-auto">
+        <div class="shadow-lg overflow-x-auto">
             <table id="patients" class="min-w-full text-sm text-gray-500">
                 <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-100">
                     <tr>
                         <th class="px-6 py-3">{% translate "Patient name" %}</th>
-                        <th class="px-6 py-3 hidden lg:table-cell">{% translate "Gender" %}</th>
-                        <th class="px-6 py-3 hidden lg:table-cell">{% translate "Date of Birth" %}</th>
-                        <th class="px-6 py-3 hidden lg:table-cell">{% translate "Privately insured" %}?</th>
+                        <th class="px-6 py-3">{% translate "Gender" %}</th>
+                        <th class="px-6 py-3">{% translate "Date of Birth" %}</th>
+                        <th class="px-6 py-3">{% translate "Privately insured" %}?</th>
                         <th class="px-6 py-3 w-60">{% translate "Status" %}</th>
                         <th class="px-6 py-3 w-[400px] ">{% translate "Action" %}</th>
                     </tr>
                 </thead>
                 <tbody class="overflow-y-auto">
                     {% if perms.cms.add_user %}
-                        <tr class="odd:bg-white even:bg-gray-100 border-b dark:odd:bg-gray-800 dark:even:bg-gray-700 dark:border-gray-700">
-                            <td class="px-6 py-3 col-span-2 block lg:table-cell">
-                                <div class="flex flex-nowrap gap-4 flex-col md:flex-row">
+                        <tr class="odd:bg-white even:bg-gray-100 border-b dark:odd:bg-gray-800 dark:even:bg-gray-700 dark:border-gray-700 w-full">
+                            <td class="px-6 py-3 col-span-2">
+                                <h2 class="lg:hidden mb-4">{% translate "Add patient" %}</h2>
+                                <div class="flex flex-nowrap gap-4 flex-col lg:flex-row">
                                     {% render_field new_patient_form.last_name form="add-patient" %}
                                     {% render_field new_patient_form.first_name form="add-patient" %}
                                 </div>
                             </td>
-                            <td class="px-6 py-3 block lg:table-cell">{% render_field new_patient_form.gender form="add-patient" %}</td>
-                            <td class="px-6 py-3 block lg:table-cell">{% render_field new_patient_form.date_of_birth form="add-patient" %}</td>
-                            <td class="px-6 py-3 block lg:table-cell text-center">
-                                {% render_field new_patient_form.insurance_type form="add-patient" %}
-                            </td>
-                            <td class="px-6 py-3"></td>
-                            <td class="p-3 text-center">
-                                <button class="px-2 text-white bg-blue-500 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-700 rounded px-5 py-2.5 text-center"
+                            <td class="px-6 py-3">{% render_field new_patient_form.gender form="add-patient" %}</td>
+                            <td class="px-6 py-3">{% render_field new_patient_form.date_of_birth form="add-patient" %}</td>
+                            <td class="px-6 py-3 text-center">{% render_field new_patient_form.insurance_type form="add-patient" %}</td>
+                            <td class="!hidden lg:!block px-6 py-3"></td>
+                            <td class="p-4 text-right">
+                                <button class="px-2 text-white bg-blue-500 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-700 rounded px-5 py-2.5 text-center w-full lg:w-auto"
                                         form="add-patient">
                                     <form hidden
                                           id="add-patient"
@@ -59,59 +58,47 @@
                     <tr class="h-3 w-full"></tr>
                     {% for patient, patient_form in patients %}
                         <tr data-patient-id="{{ patient.id }}"
-                            class="odd:bg-white even:bg-gray-100 border-b dark:odd:bg-gray-800 dark:even:bg-gray-700 dark:border-gray-700">
+                            class="py-2 lg:py-0 odd:bg-white even:bg-gray-100 border-b dark:odd:bg-gray-800 dark:even:bg-gray-700 dark:border-gray-700">
                             <td class="px-6 py-3">
-                                <p class="py-2 px-3 text-base border border-transparent">{{ patient.last_name }}, {{ patient.first_name }}</p>
-                                <div class="hidden flex flex-nowrap gap-4 flex-col md:flex-row">
+                                <p class="py-2 lg:px-3 text-base border border-transparent text-xl lg:text-base ">
+                                    {{ patient.last_name }}, {{ patient.first_name }}
+                                </p>
+                                <div class="!hidden flex flex-nowrap gap-4 flex-col lg:flex-row">
                                     {% render_field patient_form.last_name form=patient.id %}
                                     {% render_field patient_form.first_name form=patient.id %}
                                 </div>
-                                <dl class="ml-3 lg:hidden">
-                                    <dt class="sr-only xl:hidden">{% translate "Gender" %}</dt>
-                                    <dd class="xl:hidden dark:text-gray-200">
-                                        {{ patient.gender }}
-                                    </dd>
-                                    <dt class="sr-only">{% translate "Date of Birth" %}</dt>
-                                    <dd class="xl:hidden dark:text-gray-200">
-                                        {{ patient.date_of_birth|date:'d.m.Y' }}
-                                    </dd>
-                                    <dt class="sr-only">{% translate "Privately insured" %}</dt>
-                                    <dd class="xl:hidden">
-                                        {% if patient.insurance_type %}
-                                            <i icon-name="check" class="w-4 h-4 text-green-700 dark:text-green-400"></i>
-                                        {% else %}
-                                            <i icon-name="x" class="w-4 h-4 text-red-700 dark:text-red-400"></i>
-                                        {% endif %}
-                                    </dd>
-                                </dl>
                             </td>
-                            <td class="px-6 py-3 hidden lg:table-cell">
+                            <td class="px-6 lg:py-3">
+                                <span class="lg:hidden help-text">{% translate "Gender" %}:</span>
                                 {% if patient.gender == 'm' %}
-                                    <p class="py-2 px-3 text-base border border-transparent w-full bg-blue-100 text-blue-800 text-sm font-medium px-2.5 py-0.5 rounded dark:bg-blue-900 dark:text-blue-300">
+                                    <p class="inline lg:block lg:py-2 px-3 text-base border border-transparent w-full bg-blue-100 text-blue-800 text-sm font-medium rounded dark:bg-blue-900 dark:text-blue-300">
                                         {% translate "Male" %}
                                     </p>
                                 {% elif patient.gender == 'f' %}
-                                    <p class="py-2 px-3 text-base border border-transparent w-full bg-pink-100 text-pink-800 text-sm font-medium px-2.5 py-0.5 rounded dark:bg-pink-900 dark:text-pink-300">
+                                    <p class="inline lg:block lg:py-2 px-3 text-base border border-transparent w-full bg-pink-100 text-pink-800 text-sm font-medium rounded dark:bg-pink-900 dark:text-pink-300">
                                         {% translate "Female" %}
                                     </p>
                                 {% elif patient.gender == 'd' %}
-                                    <p class="py-2 px-3 text-base border border-transparent w-full bg-green-100 text-green-800 text-sm font-medium px-2.5 py-0.5 rounded dark:bg-pink-900 dark:text-pink-300">
+                                    <p class="inline lg:block lg:py-2 px-3 text-base border border-transparent w-full bg-green-100 text-green-800 text-sm font-medium rounded dark:bg-pink-900 dark:text-pink-300">
                                         {% translate "Diverse" %}
                                     </p>
                                 {% endif %}
-                                <div class="radio-row hidden">{% render_field patient_form.gender form=patient.id %}</div>
+                                <div class="radio-row !hidden">{% render_field patient_form.gender form=patient.id %}</div>
                             </td>
-                            <td class="px-6 py-3 hidden lg:table-cell">
-                                <p class="py-2 px-3 text-base">{{ patient.date_of_birth|date:'d.m.Y' }}</p>
-                                {% render_field patient_form.date_of_birth form=patient.id class+="hidden" %}
+                            <td class="px-6 lg:py-3">
+                                <p class="lg:py-2 lg:px-3 text-base">
+                                    <span class="lg:hidden help-text">{% translate "Date of birth" %}:</span> {{ patient.date_of_birth|date:'d.m.Y' }}
+                                </p>
+                                {% render_field patient_form.date_of_birth form=patient.id class+="!hidden" %}
                             </td>
-                            <td class="px-6 py-3 text-center hidden lg:table-cell">
+                            <td class="px-6 lg:py-3 lg:text-center">
+                                <span class="lg:hidden help-text">{% translate "Privately insured" %}:</span>
                                 {% if patient.insurance_type %}
                                     <i icon-name="check" class="w-4 h-4 text-green-700 dark:text-green-400"></i>
                                 {% else %}
                                     <i icon-name="x" class="w-4 h-4 text-red-700 dark:text-red-400"></i>
                                 {% endif %}
-                                <div class="radio-row hidden">{% render_field patient_form.insurance_type form=patient.id %}</div>
+                                <div class="radio-row !hidden">{% render_field patient_form.insurance_type form=patient.id %}</div>
                             </td>
                             <td class="px-6 py-3 text-center">
                                 <span>
@@ -129,12 +116,12 @@
                                             </b>
                                         {% endif %}
                                     {% else %}
-                                        -
+                                        <span class="hidden lg:block">-</span>
                                     {% endif %}
                                 </span>
                             </td>
                             <td class="p-4">
-                                <div class="text-center flex flex-col sm:flex-row gap-1 justify-end">
+                                <div class="text-center flex flex-col sm:flex-row gap-1 lg:justify-end">
                                     {% if patient.current_stay.recommended_ward %}
                                         <a href="{% url 'cms:protected:assign_patient' ward_id=patient.current_stay.recommended_ward.id assignment_id=patient.current_stay.id %}"
                                            class="text-white border-2 border-green-500 hover:border-green-700 bg-green-500 hover:bg-green-700 focus:ring-4 focus:outline-none focus:ring-green-300 dark:focus:ring-green-700 rounded px-5 py-2.5">
@@ -153,7 +140,7 @@
                                         {% translate "Details" %}
                                     </a>
                                 </div>
-                                <div class="hidden flex flex-wrap gap-1">
+                                <div class="!hidden flex flex-col lg:flex-row flex-wrap gap-1">
                                     <button class="grow edit-patient-button text-white bg-blue-500 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-700 rounded px-5 py-2.5">
                                         {% translate "Cancel" %}
                                     </button>

--- a/ycms/cms/templates/timeline/timeline.html
+++ b/ycms/cms/templates/timeline/timeline.html
@@ -10,35 +10,34 @@
             <div class="flex flex-col gap-2 xl:flex-row rounded-lg border border-gray-300 bg-white shadow-md flex flex-nowrap h-full items-center justify-between p-4 mb-4 hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700">
                 {% include "ward/ward_selection_form.html" %}
                 <div id="change-counter"
-                     class="hidden flex flex-col lg:flex-row items-center gap-2 dark:text-white">
+                     class="hidden flex flex-wrap lg:flex-nowrap items-center gap-2 dark:text-white">
                     <div class="shrink-0">
                         <span>0</span>
                         {% translate "unsaved bed assignment changes" %}
                     </div>
-                    <div class="grid grid-cols-2 gap-2 w-full">
-                        <form enctype="multipart/form-data"
-                              method="post"
-                              id="timeline-changes-form"
-                              class="flex items-center w-full">
-                            {% csrf_token %}
-                            <input type="hidden" name="timeline_changes" id="timeline-changes" />
-                            <button class="w-full text-white bg-green-500 hover:bg-green-700 focus:ring-4 focus:outline-none focus:ring-green-300 rounded inline-flex items-center justify-center px-5 py-2.5 text-center">
-                                {% translate "Save" %}
-                            </button>
-                        </form>
-                        <a href="{% url "cms:protected:timeline" selected_ward_id %}"
-                           class="w-full lg:w-auto lg:col-span-1 text-center text-red-700 border-red-700 border-2 hover:border-red-800 dark:text-white hover:text-white hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 rounded px-5 py-2 dark:hover:bg-red-700 dark:focus:ring-red-800">
-                            {% translate "Cancel" %}
-                        </a>
-                        {% if "/suggest/" not in request.path %}
-                            <a href="{% url "cms:protected:timeline_suggest" selected_ward_id %}"
-                               class="btn w-full col-span-2">
-                                <i icon-name="bot" class="mr-2 align-text-bottom"></i>
-                                {% translate "Suggest Assignment" %}
-                            </a>
-                        {% endif %}
-                    </div>
+                    <form enctype="multipart/form-data"
+                          method="post"
+                          id="timeline-changes-form"
+                          class="flex items-center w-full">
+                        {% csrf_token %}
+                        <input type="hidden" name="timeline_changes" id="timeline-changes" />
+                        <button class="w-full lg:w-auto text-white bg-green-500 hover:bg-green-700 focus:ring-4 focus:outline-none focus:ring-green-300 rounded inline-flex items-center justify-center px-5 py-2.5 text-center">
+                            {% translate "Save" %}
+                        </button>
+                    </form>
+                    <a href="{% url "cms:protected:timeline" selected_ward_id %}"
+                       class="w-full lg:w-auto lg:col-span-1 text-center text-red-700 border-red-700 border-2 hover:border-red-800 dark:text-white hover:text-white hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 rounded px-5 py-2 dark:hover:bg-red-700 dark:focus:ring-red-800">
+                        {% translate "Cancel" %}
+                    </a>
                 </div>
+                {% if "/suggest/" not in request.path %}
+                    <a href="{% url "cms:protected:timeline_suggest" selected_ward_id %}"
+                       class="btn w-full lg:w-auto"
+                       id="autosuggest">
+                        <i icon-name="bot" class="mr-2 align-text-bottom"></i>
+                        {% translate "Suggest Assignment" %}
+                    </a>
+                {% endif %}
                 {% with checked=True %}
                     {% include "ward/ward_mode_switch.html" %}
                 {% endwith %}

--- a/ycms/locale/de/LC_MESSAGES/django.po
+++ b/ycms/locale/de/LC_MESSAGES/django.po
@@ -911,6 +911,10 @@ msgid "Action"
 msgstr "Aktion"
 
 #: cms/templates/patients/patients_list.html
+msgid "Add patient"
+msgstr "Patient*in hinzufügen"
+
+#: cms/templates/patients/patients_list.html
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -925,6 +929,10 @@ msgstr "Weiblich"
 #: cms/templates/patients/patients_list.html
 msgid "Diverse"
 msgstr "Divers"
+
+#: cms/templates/patients/patients_list.html
+msgid "Date of birth"
+msgstr "Geburtsdatum"
 
 #: cms/templates/patients/patients_list.html
 msgid "Stays in:"
@@ -1259,9 +1267,6 @@ msgstr "Englisch"
 
 #~ msgid "Home"
 #~ msgstr "Start"
-
-#~ msgid "Add new patient"
-#~ msgstr "Patient*in hinzufügen"
 
 #~ msgid "is available"
 #~ msgstr "ist verfügbar"

--- a/ycms/static/src/css/style.scss
+++ b/ycms/static/src/css/style.scss
@@ -404,3 +404,18 @@ input[type="submit"] {
 .vis-label .vis-inner {
     @apply dark:text-gray-300;
 }
+
+#patients {
+    table {
+        @apply block lg:table;
+    }
+    tr {
+        @apply block lg:table-row;
+    }
+    td {
+        @apply block lg:table-cell;
+    }
+    th {
+        @apply hidden lg:table-cell;
+    }
+}

--- a/ycms/static/src/js/patients_list.ts
+++ b/ycms/static/src/js/patients_list.ts
@@ -3,7 +3,7 @@ const editPatient = (id: string) => {
     if (row != null) {
         for (const column of row.children) {
             for (const child of column.children) {
-                child.classList.toggle("hidden");
+                child.classList.toggle("!hidden");
             }
         }
     }

--- a/ycms/static/src/js/ward/timeline.ts
+++ b/ycms/static/src/js/ward/timeline.ts
@@ -43,15 +43,18 @@ const maxConcurrentBeds = (unsortedObjects: TimelineItem[]) => {
 const showUnsaved = (totalChanges: number) => {
     const changeCounterContainer = document.querySelector("#change-counter") as HTMLElement;
     const changeCounter = document.querySelector("#change-counter span") as HTMLElement;
-    if (!changeCounterContainer || !changeCounter) {
+    const autosuggest = document.querySelector("#autosuggest") as HTMLElement;
+    if (!changeCounterContainer || !changeCounter || !autosuggest) {
         return;
     }
 
     changeCounter.innerHTML = String(totalChanges);
     if (totalChanges > 0) {
         changeCounterContainer.classList.remove("hidden");
+        autosuggest.classList.add("hidden");
     } else {
         changeCounterContainer.classList.add("hidden");
+        autosuggest.classList.remove("hidden");
     }
 };
 


### PR DESCRIPTION
<!-- Copyright [2019] [Integreat Project] -->
<!---->
<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
<!-- you may not use this file except in compliance with the License. -->
<!-- You may obtain a copy of the License at -->
<!---->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!---->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->
### Short description
<!-- Describe this PR in one or two sentences. -->
Make table in the patinets list responsive.

### Proposed changes
<!-- Describe this PR in more detail. -->

- on mobile, show a "list of cards" rather than an actual table
- make some changes to the timeline header on desktop/mobile, partly reverting changes from #127  


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- on screen sizes starting from `lg` to somewhere between `xl` and `xxl`, the table scrolls. I think it's acceptable... Not many devices in that size category, esp. during the presentation... 😅 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #130 
